### PR TITLE
Throttle fix

### DIFF
--- a/scripts/src/entrez/genbank.py
+++ b/scripts/src/entrez/genbank.py
@@ -6,7 +6,7 @@ from Bio import Entrez
 from xml.etree import ElementTree as ET
 
 from ..utils.config import Config
-from ..utils.throttle import Throttle
+from ..utils.throttle import ENDPOINTS, Throttle
 
 config = Config()
 logger = logging.getLogger(__name__)
@@ -144,10 +144,7 @@ def fetch_entrez(
     kwargs.update({
         "db": db,
     })
-    throttle = Throttle(
-        interval_sec=config.ENTREZ_INTERVAL_SEC,
-        lock_file=config.entrez_lock_file,
-    )
+    throttle = Throttle(ENDPOINTS.ENTREZ)
     handle = throttle.with_retry(endpoint, kwargs=kwargs)
     data = read(handle)
     handle.close()

--- a/scripts/src/gbif/relatives.py
+++ b/scripts/src/gbif/relatives.py
@@ -5,7 +5,7 @@ import pygbif
 from functools import cached_property
 
 from ..utils import config
-from ..utils.throttle import Throttle
+from ..utils.throttle import ENDPOINTS, Throttle
 
 logger = logging.getLogger(__name__)
 config = config.Config()
@@ -55,10 +55,7 @@ class RelatedTaxaGBIF:
             'q': taxon,
             'limit': 20,
         }
-        throttle = Throttle(
-            interval_sec=config.GBIF_FAST_INTERVAL_SEC,
-            lock_file=config.gbif_fast_lock_file,
-        )
+        throttle = Throttle(ENDPOINTS.GBIF_FAST)
         res = throttle.with_retry(
             pygbif.species.name_suggest,
             kwargs=kwargs,
@@ -102,10 +99,7 @@ class RelatedTaxaGBIF:
 
         while not end_of_records:
             kwargs['offset'] = i * config.GBIF_LIMIT_RECORDS
-            throttle = Throttle(
-                interval_sec=config.GBIF_SLOW_INTERVAL_SEC,
-                lock_file=config.gbif_slow_lock_file,
-            )
+            throttle = Throttle(ENDPOINTS.GBIF_SLOW)
             res = throttle.with_retry(
                 pygbif.species.name_lookup,
                 kwargs=kwargs,
@@ -149,10 +143,7 @@ class RelatedTaxaGBIF:
                 'offset': i * config.GBIF_LIMIT_RECORDS,
                 'limit': 1,  # don't need every occurence for each species
             }
-            throttle = Throttle(
-                interval_sec=config.GBIF_FAST_INTERVAL_SEC,
-                lock_file=config.gbif_fast_lock_file,
-            )
+            throttle = Throttle(ENDPOINTS.GBIF_FAST)
             res = throttle.with_retry(
                 pygbif.occurrences.search,
                 kwargs=kwargs,

--- a/scripts/src/utils/config.py
+++ b/scripts/src/utils/config.py
@@ -74,20 +74,13 @@ class Config:
     LOG_FILENAME = 'run.log'
     QUERY_LOG_FILENAME = 'query.log'
     ENTREZ_CACHE_DIRNAME = 'entrez_cache'
-    ENTREZ_LOCK_FILE = 'entrez.lock'
-    ENTREZ_INTERVAL_SEC = 0.2
-    GBIF_FAST_INTERVAL_SEC = 0.2
-    GBIF_SLOW_INTERVAL_SEC = 0.8
-    GBIF_FAST_LOCK_FILE = 'gbif-fast.lock'
-    GBIF_SLOW_LOCK_FILE = 'gbif-slow.lock'
+    THROTTLE_SQLITE_FILE = 'throttle.sqlite'
     MAX_API_RETRIES = 3
     ERRORS_DIR = 'errors'
 
     TEMP_FILES = [
-        ENTREZ_LOCK_FILE,
         ENTREZ_CACHE_DIRNAME,
-        GBIF_FAST_LOCK_FILE,
-        GBIF_SLOW_LOCK_FILE,
+        THROTTLE_SQLITE_FILE,
     ]
 
     class INPUTS:
@@ -198,20 +191,12 @@ class Config:
         return self.output_dir / self.TAXONOMY_FILE
 
     @property
-    def entrez_lock_file(self):
-        return self.output_dir / self.ENTREZ_LOCK_FILE
-
-    @property
     def entrez_cache_dir(self):
         return self.output_dir / self.ENTREZ_CACHE_DIRNAME
 
     @property
-    def gbif_slow_lock_file(self):
-        return self.output_dir / self.GBIF_SLOW_LOCK_FILE
-
-    @property
-    def gbif_fast_lock_file(self):
-        return self.output_dir / self.GBIF_FAST_LOCK_FILE
+    def throttle_sqlite_path(self):
+        return self.output_dir / self.THROTTLE_SQLITE_FILE
 
     @property
     def start_time(self) -> datetime:

--- a/scripts/src/utils/throttle.py
+++ b/scripts/src/utils/throttle.py
@@ -1,7 +1,7 @@
-import fcntl
 import logging
+import random
+import sqlite3
 import time
-from pathlib import Path
 from pprint import pformat
 
 from .config import Config
@@ -11,56 +11,116 @@ config = Config()
 logger = logging.getLogger(__name__)
 
 
+class ENDPOINTS:
+    GBIF_SLOW = {
+        'requests_per_second': 1,
+        'name': 'gbif_slow',
+    }
+    GBIF_FAST = {
+        'requests_per_second': 10,
+        'name': 'gbif_fast',
+    }
+    ENTREZ = {
+        'requests_per_second': 10,
+        'name': 'entrez',
+    }
+
+
 class Throttle:
-    """Use filelock to throttle requests to the GBIF API.
+    """Use SQLite2 database to coordinate throttling of API requests.
 
-    This is necessary to avoid hitting the rate limit of the GBIF API, or
-    overwhelming the server.
+    This is necessary to avoid hitting API rate limits, or overwhelming the
+    server. Each endpoint (identified by name) is throttled independently to
+    allow for request rates to be set per-service, and to for throttles to be
+    managed independently.
 
-    A custom interval and lock file can be set to allow for different
-    throttling intervals for each endpoint.
+    The endpoint arg should be a dict of:
+        {
+          'requests_per_second': int,  # Max requests per second
+          'name': str,                 # Name to identify this endpoint
+        }
     """
+
+    FIELD_NAME = 'timestamp'
 
     def __init__(
         self,
-        interval_sec: int,
-        lock_file: Path,
+        endpoint: dict,
     ):
-        self.interval_sec = interval_sec
-        self.lockfile = lock_file
-        self._write_lockfile()
+        self.requests_per_second = endpoint['requests_per_second']
+        self.db_path = config.throttle_sqlite_path
+        self.name = endpoint['name']
+        self._initialize_db()
 
     def __enter__(self):
-        self.acquire()
+        self.await_release()
 
     def __exit__(self, exc_type, exc_value, traceback):
         pass
 
-    def _write_lockfile(self):
-        """Ensures the lock file exists."""
-        if not self.lockfile.exists():
-            with open(self.lockfile, "w") as f:
-                f.write("")
+    def _initialize_db(self):
+        """Create table for tracking request timestamps."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(f"""
+                CREATE TABLE IF NOT EXISTS {self.name} (
+                    {self.FIELD_NAME} INTEGER
+                )
+            """)
+            conn.commit()
 
-    def acquire(self):
+    def await_release(self):
+        """Query sqlite DB for permission to send a request.
+
+        The DB table keeps track of requests sent across processes by writing
+        a timestamp for each request. If the number of requests in the last
+        second exceeds the limit, the request is blocked until the sliding
+        window is clear.
+        """
         while True:
-            try:
-                with open(self.lockfile, "r+") as f:
-                    fcntl.flock(f, fcntl.LOCK_EX)  # Lock the file
-                    time.sleep(self.interval_sec)
-                    fcntl.flock(f, fcntl.LOCK_UN)  # Unlock the file
-                    return
-            except (FileNotFoundError, ValueError):
-                self._write_lockfile()
+            with sqlite3.connect(self.db_path, isolation_level=None) as conn:
+                try:
+                    # Lock the database for writing
+                    conn.execute("BEGIN IMMEDIATE")
 
-            time.sleep(0.1)  # Wait before retrying
+                    now = int(time.time() * 1000)
+                    window_start = now - 2000  # Two-second sliding window
+
+                    # Remove expired timestamps (older than 1s)
+                    conn.execute(
+                        f"DELETE FROM {self.name} WHERE {self.FIELD_NAME} < ?",
+                        (window_start,))
+
+                    # Count remaining requests in the last second
+                    request_count = conn.execute(
+                        f"SELECT COUNT(*) FROM {self.name}"
+                    ).fetchone()[0]
+
+                    if request_count < self.requests_per_second:
+                        # Insert current timestamp atomically
+                        conn.execute(
+                            f"INSERT INTO {self.name} ({self.FIELD_NAME})"
+                            " VALUES (?)",
+                            (now,)
+                        )
+                        conn.commit()
+                        return
+
+                    # Rollback if the request limit is exceeded
+                    conn.rollback()
+
+                except sqlite3.OperationalError:
+                    # Handle potential lock contention gracefully
+                    pass
+
+            # Sleep for a random interval to reduce race conditions collisions
+            time.sleep(round(random.uniform(0.01, 0.1), 3))
 
     def with_retry(self, func, args=[], kwargs={}):
         retries = config.MAX_API_RETRIES
         while True:
             try:
                 with self:
-                    logger.debug("Lock acquired. Sending request to"
+                    logger.debug("Throttle released. Sending request to"
                                  f" {func.__name__}...")
                     return func(*args, **kwargs)
             except Exception as exc:
@@ -71,11 +131,11 @@ class Throttle:
                     logger.warning(
                         "Entrez rate limit exceeded. Waiting 10 minutes before"
                         " next retry.")
-                    retries = config.ENTREZ_MAX_RETRIES
+                    retries = config.MAX_API_RETRIES
                 elif retries <= 0:
                     raise APIError(
                         'Failed to fetch data from GBIF API after'
-                        f' {config.GBIF_MAX_RETRIES} retries. Please try'
+                        f' {config.MAX_API_RETRIES} retries. Please try'
                         f' resuming this job at a later time.'
                         f'\nException: {exc}'
                     )


### PR DESCRIPTION
Use a SQLite3 database to coordinate per-run throttling of API endpoints.

Specify your API `ENDPOINT`:
https://github.com/qcif/daff-biosecurity-wf2/blob/8420246aa47a3b38b68373058b5c8ab9e027e557/scripts/src/utils/throttle.py#L14-L18

Then send your requests through a throttle:
https://github.com/qcif/daff-biosecurity-wf2/blob/8420246aa47a3b38b68373058b5c8ab9e027e557/scripts/src/entrez/genbank.py#L147-L148

This ensures that parallel requests across threads/instances do not exceed the rate limit for that endpoint. For example, the NCBI Entrez endpoint has a rate limit of 10 requests/sec. The `throttle.with_retry` will retry the request up to 3 times before raising an exception, but will wait for 10 minutes if the rate limit is exceeded (HTTP 429).

If you don't want to use the `with_retry` method you can use the throttle directly like:

```py
throttle = Throttle(ENDPOINTS.ENTREZ)
with throttle:
    # Send your request here
    res = requests.get(url)
```